### PR TITLE
Add support for replica set clusters

### DIFF
--- a/mongo_pool/mongo_pool.py
+++ b/mongo_pool/mongo_pool.py
@@ -93,6 +93,10 @@ class MongoPool(object):
                 not isinstance(cfg['read_preference'], str)):
                 raise TypeError('Read_preference must be a string')
 
+            if ('replicaSet' in cfg and
+                not isinstance(cfg['replicaSet'], str)):
+                raise TypeError('replicaSet must be a string')
+
     def _parse_configs(self, config):
         """Builds a dict with information to connect to Clusters.
 
@@ -126,6 +130,7 @@ class MongoPool(object):
                     'host': cfg['host'],
                     'port': cfg['port'],
                     'read_preference': read_preference,
+                    'replicaSet': cfg.get('replicaSet')
                 },
                 'pattern': pattern,
                 'label': label

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ long_description = read('README.md')
 
 setup(
     name='mongo-pool',
-    version='0.4.1',
+    version='0.4.2',
     url='http://github.com/ubervu/mongo-pool/',
     description='The tool that keeps all your mongos in one place',
     long_description=long_description,


### PR DESCRIPTION
### Need

Mongo 3 supports passing replicaSet and it will be nice to support it in the cluster config too.

### Deliverables

- replicaSet param is passed in params and a MongoClient is correctly instantiated with it